### PR TITLE
Add delete analysis with confirmation

### DIFF
--- a/core/templates/core/analysis_detail.html
+++ b/core/templates/core/analysis_detail.html
@@ -107,6 +107,11 @@
 <p style="margin-top: 20px;"><a href="{% url 'event_detail' analysis.event.id %}">&larr; Back to {{ analysis.event.name }}</a></p>
 <p><a href="{% url 'video_detail' analysis.video.id %}" style="font-size: 13px;">New analysis from video</a></p>
 
+<form method="post" action="{% url 'analysis_delete' analysis.id %}" onsubmit="return confirm('Delete this analysis and all its marks? This cannot be undone.');" style="position: fixed; bottom: 20px; right: 20px; z-index: 1000;">
+    {% csrf_token %}
+    <button type="submit" style="background: #dc3545; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer;">Delete analysis</button>
+</form>
+
 <script src="{% static 'core/timeline.js' %}"></script>
 <script>
 window.ANALYSIS_ID = {{ analysis.id }};

--- a/core/urls.py
+++ b/core/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path('analyses/<int:analysis_id>', views.analysis_detail, name='analysis_detail'),
     path('analyses/<int:analysis_id>/marks', views.analysis_save_marks, name='analysis_save_marks'),
     path('analyses/<int:analysis_id>/update', views.analysis_update, name='analysis_update'),
+    path('analyses/<int:analysis_id>/delete', views.analysis_delete, name='analysis_delete'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -271,6 +271,14 @@ def analysis_update(request, analysis_id):
 
 
 @require_POST
+def analysis_delete(request, analysis_id):
+    analysis = get_object_or_404(Analysis, pk=analysis_id)
+    event_id = analysis.event_id
+    analysis.delete()
+    return redirect('event_detail', event_id=event_id)
+
+
+@require_POST
 def video_upload(request, event_id):
     event = get_object_or_404(Event, pk=event_id)
 


### PR DESCRIPTION
- analysis_delete view, redirects to event after delete
- Delete button fixed at bottom-right of analysis page
- Confirmation prompt before delete (marks cascade)

